### PR TITLE
Added tngbench share folder to Dockers

### DIFF
--- a/docker-vnfs/suricata-ids/Dockerfile
+++ b/docker-vnfs/suricata-ids/Dockerfile
@@ -39,4 +39,6 @@ RUN chmod +x start.sh
 ENV IFIN input
 ENV IFOUT output
 
+RUN mkdir /tngbench_share
+
 CMD /bin/bash

--- a/docker-vnfs/tng-bench-mp/Dockerfile
+++ b/docker-vnfs/tng-bench-mp/Dockerfile
@@ -61,6 +61,6 @@ RUN pip install virtualenv
 RUN python setup.py install
 
 WORKDIR /
-
+RUN mkdir /tngbench_share
 CMD /bin/bash
 


### PR DESCRIPTION
Our benchmarker needs those folders inside the containers to share results and logs to the controller. Should have any effect to other tools/setups.

Signed-off-by: peusterm <manuel.peuster@uni-paderborn.de>